### PR TITLE
Add onboarding pages

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -40,3 +40,16 @@
 .read-the-docs {
   color: #888;
 }
+
+.onboarding-slide {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 80vh;
+  gap: 1rem;
+}
+
+.onboarding-slide button {
+  margin-top: 1rem;
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,21 +1,37 @@
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Link,
+  useLocation,
+} from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Onboarding from './pages/Onboarding';
 import './App.css';
+
+function Nav() {
+  const location = useLocation();
+  if (location.pathname === '/') return null;
+  return (
+    <nav>
+      <Link to="/dashboard">Dashboard</Link> |{' '}
+      <Link to="/wallet">Wallet</Link> |{' '}
+      <Link to="/swap">Swap</Link> |{' '}
+      <Link to="/alerts">Alerts</Link>
+    </nav>
+  );
+}
 
 function App() {
   return (
     <Router>
-      <nav>
-        <Link to="/">Dashboard</Link> |{' '}
-        <Link to="/wallet">Wallet</Link> |{' '}
-        <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
-      </nav>
+      <Nav />
       <Routes>
-        <Route path="/" element={<Dashboard />} />
+        <Route path="/" element={<Onboarding />} />
+        <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />

--- a/client/src/pages/Onboarding.tsx
+++ b/client/src/pages/Onboarding.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import '../App.css';
+
+interface Slide {
+  title: string;
+  text: string;
+  button?: string;
+  final?: boolean;
+}
+
+const slides: Slide[] = [
+  {
+    title: 'Bienvenido a ScreenerWallet',
+    text: 'tu aliado en el trading de tokens Solana',
+    button: 'Comenzar ahora',
+  },
+  {
+    title: 'Dashboard en tiempo real',
+    text: 'Monitorea precios y movimientos de mercado al instante.',
+  },
+  {
+    title: 'Wallet segura integrada',
+    text: 'Guarda y gestiona tus activos sin salir de la app.',
+  },
+  {
+    title: 'Trading ultra r\u00e1pido',
+    text: 'Ejecuta swaps y \u00f3rdenes avanzadas en segundos.',
+  },
+  {
+    title: 'Alertas inteligentes',
+    text: 'Recibe alertas personalizadas y no pierdas ninguna oportunidad.',
+    final: true,
+  },
+];
+
+export default function Onboarding() {
+  const [index, setIndex] = useState(0);
+  const navigate = useNavigate();
+
+  const next = () => setIndex((i) => Math.min(i + 1, slides.length - 1));
+  const start = () => navigate('/dashboard');
+
+  const slide = slides[index];
+  return (
+    <div className="onboarding-slide">
+      <h2>{slide.title}</h2>
+      <p>{slide.text}</p>
+      {slide.final ? (
+        <div>
+          <button onClick={start}>Registrarme ahora</button>{' '}
+          <button onClick={start}>Ya tengo cuenta</button>
+        </div>
+      ) : (
+        <button onClick={next}>{slide.button || 'Siguiente'}</button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple onboarding slides
- load onboarding at root route
- hide nav on onboarding screen

## Testing
- `npm run lint` in `client`
- `npm test` in `server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684557604980832e85dc88765a00e882