### PR TITLE
Add login and recovery pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,8 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Login from './pages/Login';
+import ForgotPassword from './pages/ForgotPassword';
 import './App.css';
 
 function App() {
@@ -19,6 +21,8 @@ function App() {
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword.tsx
@@ -1,0 +1,14 @@
+import '../index.css';
+
+function ForgotPassword() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '1rem' }}>
+      <h2>Recuperar Contraseña</h2>
+      <p>Recibirás un enlace para restablecer tu contraseña.</p>
+      <input type="email" placeholder="tu@email.com" style={{ padding: '0.5rem', width: '250px' }} />
+      <button style={{ width: '250px' }}>Enviar enlace</button>
+    </div>
+  );
+}
+
+export default ForgotPassword;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import '../index.css';
+
+function Login() {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '1rem' }}>
+      <img src="/vite.svg" alt="Logo" style={{ width: '80px', marginBottom: '1rem' }} />
+      <input
+        type="text"
+        placeholder="usuario@email.com"
+        style={{ padding: '0.5rem', width: '250px' }}
+      />
+      <div style={{ position: 'relative' }}>
+        <input
+          type={showPassword ? 'text' : 'password'}
+          placeholder="Contraseña"
+          style={{ padding: '0.5rem', width: '250px' }}
+        />
+        <button
+          type="button"
+          onClick={() => setShowPassword(!showPassword)}
+          style={{ position: 'absolute', right: '0', top: '0', height: '100%' }}
+        >
+          {showPassword ? 'Ocultar' : 'Mostrar'}
+        </button>
+      </div>
+      <a href="/forgot-password" style={{ fontSize: '0.8rem' }}>Olvidé mi contraseña</a>
+      <button style={{ width: '250px' }}>Ingresar</button>
+      <div style={{ textAlign: 'center' }}>
+        <p>O entra con tu cuenta social</p>
+        <div style={{ display: 'flex', justifyContent: 'center', gap: '1rem' }}>
+          <button>Google</button>
+          <button>Apple</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Login;


### PR DESCRIPTION
## Summary
- create Login and ForgotPassword pages
- hook new pages into router

## Testing
- `npm install` in `client`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845577e75ec832eace98ce6a8ce218b