### PR TITLE
Implement basic dashboard layout

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -3,6 +3,7 @@
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
+  padding-bottom: 4rem; /* space for bottom nav */
 }
 
 .logo {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,25 +1,25 @@
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Profile from './pages/Profile';
+import TokenDetail from './pages/TokenDetail';
+import BottomNav from './components/BottomNav';
 import './App.css';
 
 function App() {
   return (
     <Router>
-      <nav>
-        <Link to="/">Dashboard</Link> |{' '}
-        <Link to="/wallet">Wallet</Link> |{' '}
-        <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
-      </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/profile" element={<Profile />} />
+        <Route path="/token/:symbol" element={<TokenDetail />} />
       </Routes>
+      <BottomNav />
     </Router>
   );
 }

--- a/client/src/components/BottomNav.css
+++ b/client/src/components/BottomNav.css
@@ -1,0 +1,20 @@
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  background: #333;
+  padding: 0.5rem 0;
+}
+
+.bottom-nav a {
+  color: #fff;
+  text-decoration: none;
+  font-size: 1.5rem;
+}
+
+.bottom-nav a.active {
+  color: #61dafb;
+}

--- a/client/src/components/BottomNav.tsx
+++ b/client/src/components/BottomNav.tsx
@@ -1,0 +1,18 @@
+import { Link, useLocation } from 'react-router-dom';
+import './BottomNav.css';
+
+export default function BottomNav() {
+  const location = useLocation();
+
+  const isActive = (path: string) => location.pathname === path;
+
+  return (
+    <nav className="bottom-nav">
+      <Link to="/" className={isActive('/') ? 'active' : ''}>🏠</Link>
+      <Link to="/swap" className={isActive('/swap') ? 'active' : ''}>📈</Link>
+      <Link to="/wallet" className={isActive('/wallet') ? 'active' : ''}>👛</Link>
+      <Link to="/alerts" className={isActive('/alerts') ? 'active' : ''}>🔔</Link>
+      <Link to="/profile" className={isActive('/profile') ? 'active' : ''}>👤</Link>
+    </nav>
+  );
+}

--- a/client/src/pages/Dashboard.css
+++ b/client/src/pages/Dashboard.css
@@ -1,0 +1,45 @@
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.portfolio {
+  font-size: 1.5rem;
+}
+
+.alert-icon {
+  font-size: 1.5rem;
+  text-decoration: none;
+}
+
+.token-tabs {
+  margin: 1rem 0;
+}
+.token-tabs button {
+  margin-right: 0.5rem;
+}
+
+.token-list {
+  list-style: none;
+  padding: 0;
+}
+.token-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #444;
+}
+.token-list a {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+.token-list .positive {
+  color: #00ff00;
+}
+.token-list .negative {
+  color: #ff5050;
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,31 +1,73 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import './Dashboard.css';
 
-interface PriceData {
-  pair: string;
-  priceUsd: string;
+interface TokenInfo {
+  symbol: string;
+  icon: string;
+  priceUsd: number;
+  change24h: number;
 }
 
-export default function Dashboard() {
-  const [data, setData] = useState<PriceData | null>(null);
+const tokens: TokenInfo[] = [
+  { symbol: 'SOL', icon: '🪙', priceUsd: 150, change24h: 2.5 },
+  { symbol: 'ETH', icon: '💎', priceUsd: 3300, change24h: -1.2 },
+  { symbol: 'BTC', icon: '🪙', priceUsd: 68000, change24h: 3.1 },
+];
 
-  useEffect(() => {
-    fetch('http://localhost:3001/api/prices?token=solana')
-      .then(res => res.json())
-      .then(json => setData(json.pairs ? json.pairs[0] : null))
-      .catch(console.error);
-  }, []);
+export default function Dashboard() {
+  const [tab, setTab] = useState<'gains' | 'losses' | 'trends'>('gains');
+
+  const sortedGains = [...tokens].sort((a, b) => b.change24h - a.change24h);
+  const sortedLosses = [...tokens].sort((a, b) => a.change24h - b.change24h);
+
+  const getTabData = () => {
+    switch (tab) {
+      case 'gains':
+        return sortedGains;
+      case 'losses':
+        return sortedLosses;
+      default:
+        return tokens;
+    }
+  };
+
+  const portfolioUsd = tokens.reduce((sum, t) => sum + t.priceUsd, 0);
+  const portfolioSol = portfolioUsd / 150; // placeholder conversion
+  const variation = tokens.reduce((sum, t) => sum + t.change24h, 0) / tokens.length;
 
   return (
     <div>
-      <h2>Dashboard</h2>
-      {data ? (
-        <div>
-          <p>{data.pair}</p>
-          <p>Price: ${data.priceUsd}</p>
+      <div className="dashboard-header">
+        <div className="portfolio">
+          <div>Total: ${portfolioUsd.toFixed(2)} USD</div>
+          <div>{portfolioSol.toFixed(2)} SOL</div>
+          <div className={variation >= 0 ? 'positive' : 'negative'}>
+            {variation.toFixed(2)}% 24h
+          </div>
         </div>
-      ) : (
-        <p>Loading...</p>
-      )}
+        <Link to="/alerts" className="alert-icon">🔔</Link>
+      </div>
+
+      <div className="token-tabs">
+        <button onClick={() => setTab('gains')}>Top Ganancias</button>
+        <button onClick={() => setTab('losses')}>Top Pérdidas</button>
+        <button onClick={() => setTab('trends')}>Tendencias recientes</button>
+      </div>
+      <ul className="token-list">
+        {getTabData().map(token => (
+          <li key={token.symbol}>
+            <Link to={`/token/${token.symbol}`}>
+              <span>{token.icon}</span>
+              <span>{token.symbol}</span>
+              <span>${token.priceUsd}</span>
+              <span className={token.change24h >= 0 ? 'positive' : 'negative'}>
+                {token.change24h}%
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -1,0 +1,8 @@
+export default function Profile() {
+  return (
+    <div>
+      <h2>Perfil</h2>
+      <p>Configuración de usuario (próximamente)</p>
+    </div>
+  );
+}

--- a/client/src/pages/TokenDetail.tsx
+++ b/client/src/pages/TokenDetail.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+interface PriceData {
+  pair: string;
+  priceUsd: string;
+  priceChange: string;
+}
+
+export default function TokenDetail() {
+  const { symbol } = useParams<{ symbol: string }>();
+  const [data, setData] = useState<PriceData | null>(null);
+
+  useEffect(() => {
+    if (!symbol) return;
+    fetch(`http://localhost:3001/api/prices?token=${symbol}`)
+      .then(res => res.json())
+      .then(json => {
+        if (json.pairs && json.pairs[0]) {
+          const pair = json.pairs[0];
+          setData({
+            pair: pair.baseToken.symbol,
+            priceUsd: pair.priceUsd,
+            priceChange: pair.priceChange.h24,
+          });
+        }
+      })
+      .catch(console.error);
+  }, [symbol]);
+
+  return (
+    <div>
+      <h2>Token {symbol}</h2>
+      {data ? (
+        <div>
+          <p>Precio: ${data.priceUsd}</p>
+          <p>Cambio 24h: {data.priceChange}%</p>
+        </div>
+      ) : (
+        <p>Cargando...</p>
+      )}
+      <Link to="/">Volver</Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add bottom navigation component for easy navigation
- create placeholder profile and token detail pages
- build out dashboard with tabs for top gains, losses, and trends
- style dashboard and bottom navigation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68455786a944832e9c1e2f8752c5b84b