### PR TITLE
Make RPC URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ npm run dev
 ```
 
 Open `http://localhost:5173` to view the React app.
+
+### Environment Variables
+
+Create a `.env` file inside the `client` directory and set the Solana RPC URL
+used by the wallet:
+
+```
+VITE_RPC_URL=https://your.solana.rpc/url
+```
+
+Vite exposes variables prefixed with `VITE_` to the client application. This
+value is required for network requests performed by the wallet screen.

--- a/client/src/pages/Wallet.tsx
+++ b/client/src/pages/Wallet.tsx
@@ -9,7 +9,9 @@ export default function Wallet() {
     const key = localStorage.getItem('wallet');
     if (key) {
       setPubkey(key);
-      const connection = new Connection('https://api.mainnet-beta.solana.com');
+      const rpcUrl = import.meta.env.VITE_RPC_URL ||
+        'https://api.mainnet-beta.solana.com';
+      const connection = new Connection(rpcUrl);
       connection.getBalance(new PublicKey(key)).then((lamports: number) => {
         setBalance(lamports / 1e9);
       });


### PR DESCRIPTION
## Summary
- allow RPC url to be configured via `VITE_RPC_URL`
- document required `.env` variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS errors and missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68464495e55c832ea7bc3746f8b5a6a2