### PR TITLE
Add manual wallet input

### DIFF
--- a/client/src/pages/Wallet.tsx
+++ b/client/src/pages/Wallet.tsx
@@ -4,21 +4,57 @@ import { Connection, PublicKey } from '@solana/web3.js';
 export default function Wallet() {
   const [balance, setBalance] = useState<number | null>(null);
   const [pubkey, setPubkey] = useState<string>('');
+  const [inputKey, setInputKey] = useState('');
 
   useEffect(() => {
     const key = localStorage.getItem('wallet');
     if (key) {
       setPubkey(key);
-      const connection = new Connection('https://api.mainnet-beta.solana.com');
-      connection.getBalance(new PublicKey(key)).then((lamports: number) => {
-        setBalance(lamports / 1e9);
-      });
     }
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === 'wallet') {
+        setPubkey(e.newValue || '');
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
   }, []);
+
+  useEffect(() => {
+    if (pubkey) {
+      const connection = new Connection('https://api.mainnet-beta.solana.com');
+      connection
+        .getBalance(new PublicKey(pubkey))
+        .then((lamports: number) => {
+          setBalance(lamports / 1e9);
+        })
+        .catch(() => setBalance(null));
+    } else {
+      setBalance(null);
+    }
+  }, [pubkey]);
+
+  const handleLoad = () => {
+    if (inputKey) {
+      localStorage.setItem('wallet', inputKey);
+      setPubkey(inputKey);
+      setInputKey('');
+    }
+  };
 
   return (
     <div>
       <h2>Wallet</h2>
+      <div>
+        <input
+          value={inputKey}
+          onChange={e => setInputKey(e.target.value)}
+          placeholder="Enter public key"
+        />
+        <button onClick={handleLoad}>Load</button>
+      </div>
       {pubkey ? <p>Address: {pubkey}</p> : <p>No wallet loaded</p>}
       {balance !== null && <p>Balance: {balance} SOL</p>}
     </div>


### PR DESCRIPTION
## Summary
- allow manually entering public key in wallet page
- store provided key in localStorage and reload balance when changed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: multiple TS errors in other files)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684644994ae8832eaf0f2bdef8482c38