### PR TITLE
Ignore client build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 client/node_modules
 server/node_modules
 dist
+client/dist
 .env


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore `client/dist`

No other build files were present in the repository.


------
https://chatgpt.com/codex/tasks/task_e_684644b07590832ea632fe3d05974b8f