### PR TITLE
Add transaction history page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import History from './pages/History';
 import './App.css';
 
 function App() {
@@ -12,13 +13,15 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/history">Historial</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/history" element={<History />} />
       </Routes>
     </Router>
   );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -66,3 +66,35 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.tx-list {
+  list-style: none;
+  padding: 0;
+}
+
+.tx-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-bottom: 1px solid #888;
+  padding: 0.5rem 0;
+}
+
+.filters {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.status-completed {
+  color: #4caf50;
+}
+
+.status-pending {
+  color: #ff9800;
+}
+
+.status-failed {
+  color: #f44336;
+}

--- a/client/src/pages/History.tsx
+++ b/client/src/pages/History.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+
+interface Transaction {
+  id: number;
+  type: 'swap' | 'send' | 'receive';
+  date: string; // ISO string
+  amount: number;
+  token: string;
+  status: 'completed' | 'pending' | 'failed';
+}
+
+const sampleData: Transaction[] = [
+  {
+    id: 1,
+    type: 'swap',
+    date: '2024-04-01T10:24:00Z',
+    amount: 1.5,
+    token: 'SOL',
+    status: 'completed',
+  },
+  {
+    id: 2,
+    type: 'send',
+    date: '2024-04-02T12:10:00Z',
+    amount: 3,
+    token: 'USDC',
+    status: 'pending',
+  },
+  {
+    id: 3,
+    type: 'receive',
+    date: '2024-04-03T08:05:00Z',
+    amount: 5,
+    token: 'SOL',
+    status: 'failed',
+  },
+];
+
+function icon(type: Transaction['type']): string {
+  switch (type) {
+    case 'swap':
+      return '\uD83D\uDD04';
+    case 'send':
+      return '\uD83D\uDCE4';
+    case 'receive':
+      return '\uD83D\uDCE5';
+  }
+}
+
+export default function History() {
+  const [typeFilter, setTypeFilter] = useState<'all' | 'swap' | 'send' | 'receive'>('all');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  const filtered = sampleData
+    .filter((tx) => typeFilter === 'all' || tx.type === typeFilter)
+    .filter((tx) => (startDate ? tx.date >= startDate : true))
+    .filter((tx) => (endDate ? tx.date <= `${endDate}T23:59:59` : true))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  return (
+    <div>
+      <h2>Historial de Transacciones</h2>
+      <div className="filters">
+        <label>
+          Tipo:
+          <select
+            value={typeFilter}
+            onChange={(e) =>
+              setTypeFilter(
+                e.target.value as 'all' | 'swap' | 'send' | 'receive'
+              )
+            }
+          >
+            <option value="all">Todos</option>
+            <option value="swap">Swaps</option>
+            <option value="send">Envíos</option>
+            <option value="receive">Recibos</option>
+          </select>
+        </label>
+        <label>
+          Desde:
+          <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+        </label>
+        <label>
+          Hasta:
+          <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+        </label>
+      </div>
+      <ul className="tx-list">
+        {filtered.map((tx) => (
+          <li key={tx.id} className="tx-item">
+            <span className="tx-icon">{icon(tx.type)}</span>
+            <span>{new Date(tx.date).toLocaleString()}</span>
+            <span>
+              {tx.amount} {tx.token}
+            </span>
+            <span className={`status-${tx.status}`}>{tx.status}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement basic transaction history page with filtering
- style history entries and status colors
- wire up History page in nav and routing

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68455814ff3c832e8cc4e5fefdf3b6f6