### PR TITLE
Add sniping rules page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ npm run dev
 ```
 
 Open `http://localhost:5173` to view the React app.
+
+### Sniping Configuration
+
+The new **Sniping** page allows you to create automatic purchase rules. It can
+be accessed from the main navigation once the client is running. Rules are
+stored in memory on the server and can be managed via the following endpoints:
+
+```
+GET  /api/sniping/rules   - list configured rules
+POST /api/sniping/rules   - create a new rule
+GET  /api/sniping/snipes  - list latest snipes
+```

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Sniping from './pages/Sniping';
 import './App.css';
 
 function App() {
@@ -12,13 +13,15 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/sniping">Sniping</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/sniping" element={<Sniping />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/Sniping.tsx
+++ b/client/src/pages/Sniping.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+
+interface SnipingRule {
+  id: number;
+  liquidity: number;
+  volume: number;
+  investment: number;
+  active: boolean;
+}
+
+interface Snipe {
+  id: number;
+  token: string;
+  amount: number;
+  timestamp: number;
+}
+
+export default function Sniping() {
+  const [liquidity, setLiquidity] = useState('');
+  const [volume, setVolume] = useState('');
+  const [investment, setInvestment] = useState('');
+  const [active, setActive] = useState(true);
+
+  const [rules, setRules] = useState<SnipingRule[]>([]);
+  const [snipes, setSnipes] = useState<Snipe[]>([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/api/sniping/rules')
+      .then(res => res.json())
+      .then(setRules)
+      .catch(console.error);
+
+    fetch('http://localhost:3001/api/sniping/snipes')
+      .then(res => res.json())
+      .then(setSnipes)
+      .catch(console.error);
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const body = {
+      liquidity: Number(liquidity),
+      volume: Number(volume),
+      investment: Number(investment),
+      active,
+    };
+    fetch('http://localhost:3001/api/sniping/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+      .then(res => res.json())
+      .then(rule => {
+        setRules([...rules, rule]);
+        setLiquidity('');
+        setVolume('');
+        setInvestment('');
+        setActive(true);
+      })
+      .catch(console.error);
+  };
+
+  return (
+    <div>
+      <h2>Sniping</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Liquidez mínima (SOL/USD):
+          <input value={liquidity} onChange={e => setLiquidity(e.target.value)} />
+        </label>
+        <br />
+        <label>
+          Volumen inicial:
+          <input value={volume} onChange={e => setVolume(e.target.value)} />
+        </label>
+        <br />
+        <label>
+          Cantidad automática invertir:
+          <input value={investment} onChange={e => setInvestment(e.target.value)} />
+        </label>
+        <br />
+        <label>
+          Activa:
+          <input
+            type="checkbox"
+            checked={active}
+            onChange={e => setActive(e.target.checked)}
+          />
+        </label>
+        <br />
+        <button type="submit">Crear Regla</button>
+      </form>
+
+      <h3>Reglas</h3>
+      <ul>
+        {rules.map(rule => (
+          <li key={rule.id}>
+            Liquidez: {rule.liquidity} | Volumen: {rule.volume} | Inversión:{' '}
+            {rule.investment} | {rule.active ? 'Activa' : 'Inactiva'}
+          </li>
+        ))}
+      </ul>
+
+      <h3>Últimos snipes</h3>
+      <ul>
+        {snipes.map(snipe => (
+          <li key={snipe.id}>
+            {new Date(snipe.timestamp).toLocaleString()} - {snipe.token} - {snipe.amount}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,10 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// In-memory storage for sniping rules and executed snipes
+const snipingRules = [];
+const snipes = [];
+
 // Simple health endpoint
 app.get('/', (req, res) => {
   res.json({ status: 'ok' });
@@ -22,6 +26,32 @@ app.get('/api/prices', async (req, res) => {
     console.error(err);
     res.status(500).json({ error: 'Failed to fetch price data' });
   }
+});
+
+// Retrieve existing sniping rules
+app.get('/api/sniping/rules', (req, res) => {
+  res.json(snipingRules);
+});
+
+// Create a new sniping rule
+app.post('/api/sniping/rules', (req, res) => {
+  const rule = { id: Date.now(), ...req.body };
+  snipingRules.push(rule);
+  res.json(rule);
+});
+
+// Retrieve the last executed snipes
+app.get('/api/sniping/snipes', (req, res) => {
+  res.json(snipes);
+});
+
+// Record a new snipe (for demo purposes)
+app.post('/api/sniping/snipes', (req, res) => {
+  const snipe = { id: Date.now(), timestamp: Date.now(), ...req.body };
+  snipes.unshift(snipe);
+  // Keep only the latest 10 snipes
+  if (snipes.length > 10) snipes.pop();
+  res.json(snipe);
 });
 
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- add server endpoints to store sniping rules and executed snipes
- show sniping configuration page in React
- document sniping endpoints

## Testing
- `npm test` *(fails: no test specified)*
- `cd server && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68455822f1c8832ebd2ba1eb2df509ed