### PR TITLE
Add copy trading configuration page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ npm run dev
 ```
 
 Open `http://localhost:5173` to view the React app.
+
+### Copy Trading
+
+Navigate to `/copy-trading` in the app to explore popular traders and configure
+your copy settings. Follow or unfollow traders and set the percentage of your
+balance to copy for each one.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import CopyTrading from './pages/CopyTrading';
 import './App.css';
 
 function App() {
@@ -12,13 +13,15 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/copy-trading">Copy Trading</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/copy-trading" element={<CopyTrading />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/CopyTrading.tsx
+++ b/client/src/pages/CopyTrading.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+
+interface Trader {
+  alias: string;
+  address: string;
+}
+
+interface FollowedTrader extends Trader {
+  copyPercent: number;
+  active: boolean;
+}
+
+const popularTraders: Trader[] = [
+  { alias: 'Trader Alpha', address: '0xAlpha' },
+  { alias: 'Trader Beta', address: '0xBeta' },
+  { alias: 'Trader Gamma', address: '0xGamma' },
+];
+
+export default function CopyTrading() {
+  const [search, setSearch] = useState('');
+  const [followed, setFollowed] = useState<FollowedTrader[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('followedTraders');
+    if (stored) {
+      setFollowed(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('followedTraders', JSON.stringify(followed));
+  }, [followed]);
+
+  const handleFollow = (trader: Trader) => {
+    setFollowed(prev => {
+      if (prev.find(t => t.address === trader.address)) {
+        return prev.filter(t => t.address !== trader.address);
+      } else {
+        return [...prev, { ...trader, copyPercent: 100, active: true }];
+      }
+    });
+  };
+
+  const updatePercent = (address: string, percent: number) => {
+    setFollowed(prev =>
+      prev.map(t => (t.address === address ? { ...t, copyPercent: percent } : t))
+    );
+  };
+
+  const toggleActive = (address: string) => {
+    setFollowed(prev =>
+      prev.map(t => (t.address === address ? { ...t, active: !t.active } : t))
+    );
+  };
+
+  const filtered = popularTraders.filter(t =>
+    t.alias.toLowerCase().includes(search.toLowerCase()) ||
+    t.address.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div>
+      <h2>Copy Trading</h2>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <input
+          type="text"
+          placeholder="Buscar trader por alias o dirección"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </div>
+
+      <h3>Explorador de traders populares</h3>
+      <ul>
+        {filtered.map(trader => {
+          const isFollowed = followed.some(t => t.address === trader.address);
+          return (
+            <li key={trader.address} style={{ marginBottom: '0.5rem' }}>
+              <strong>{trader.alias}</strong> ({trader.address})
+              <button
+                style={{ marginLeft: '1rem' }}
+                onClick={() => handleFollow(trader)}
+              >
+                {isFollowed ? 'Dejar seguir' : 'Seguir'}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <h3>Traders seguidos</h3>
+      {followed.length === 0 && <p>No sigues a ningún trader.</p>}
+      <ul>
+        {followed.map(trader => (
+          <li key={trader.address} style={{ marginBottom: '1rem' }}>
+            <strong>{trader.alias}</strong> ({trader.address})
+            <div>
+              <label>
+                Cantidad a copiar (%):
+                <input
+                  type="number"
+                  min="0"
+                  max="100"
+                  value={trader.copyPercent}
+                  onChange={e =>
+                    updatePercent(trader.address, Number(e.target.value))
+                  }
+                  style={{ marginLeft: '0.5rem', width: '60px' }}
+                />
+              </label>
+              <label style={{ marginLeft: '1rem' }}>
+                <input
+                  type="checkbox"
+                  checked={trader.active}
+                  onChange={() => toggleActive(trader.address)}
+                />{' '}
+                Activar copia
+              </label>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Copy Trading page with follow/unfollow traders, search, and copy % settings
- add navigation and route to Copy Trading page
- document copy trading page in README

## Testing
- `npm run lint` in client
- `npm run build` in client

------
https://chatgpt.com/codex/tasks/task_e_6845582a5aa0832e8c15dccc87332119