### PR TITLE
Add contract security mock features

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ npm start
 ```
 
 This starts an Express server on port 3001 and exposes `/api/prices?token=<address>`.
+It also exposes a `/api/security?token=<address>` endpoint returning mock contract
+security data used by the client.
 
 ### Client
 
@@ -23,3 +25,5 @@ npm run dev
 ```
 
 Open `http://localhost:5173` to view the React app.
+The navigation includes a **Security** page that visualizes contract security
+information using the `/api/security` endpoint.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Security from './pages/Security';
 import './App.css';
 
 function App() {
@@ -12,13 +13,15 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/security">Security</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/security" element={<Security />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/Security.tsx
+++ b/client/src/pages/Security.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+
+interface Holder {
+  address: string;
+  share: number;
+}
+
+interface Properties {
+  mintable: boolean;
+  mutable: boolean;
+  authority: string;
+}
+
+interface SecurityData {
+  token: string;
+  score: number;
+  topHolders: Holder[];
+  properties: Properties;
+  critical: boolean;
+}
+
+export default function Security() {
+  const [data, setData] = useState<SecurityData | null>(null);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/api/security?token=solana')
+      .then(res => res.json())
+      .then(setData)
+      .catch(console.error);
+  }, []);
+
+  const scoreColor = (score: number) => {
+    if (score >= 80) return 'green';
+    if (score >= 50) return 'orange';
+    return 'red';
+  };
+
+  if (!data) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <div>
+      <h2>Contract Security</h2>
+      <div style={{ fontSize: '2rem', fontWeight: 'bold', color: scoreColor(data.score) }}>
+        Score: {data.score}
+      </div>
+      {data.critical && (
+        <div style={{ color: 'red', fontSize: '1.5rem', margin: '1rem 0' }}>
+          Critical Issues Detected!
+        </div>
+      )}
+      <h3>Top Holders</h3>
+      <ul>
+        {data.topHolders.map((h, i) => (
+          <li key={i}>{h.address}: {h.share}%</li>
+        ))}
+      </ul>
+      <h3>Properties</h3>
+      <ul>
+        <li>Mintable: {data.properties.mintable ? 'Yes' : 'No'}</li>
+        <li>Mutable: {data.properties.mutable ? 'Yes' : 'No'}</li>
+        <li>Authority: {data.properties.authority}</li>
+      </ul>
+    </div>
+  );
+}

--- a/server/index.js
+++ b/server/index.js
@@ -24,5 +24,27 @@ app.get('/api/prices', async (req, res) => {
   }
 });
 
+// Placeholder endpoint for contract security information
+app.get('/api/security', (req, res) => {
+  const { token } = req.query;
+  // In a real implementation this would query an on-chain indexer or security API
+  // For now return mocked data so the UI can display something useful
+  res.json({
+    token,
+    score: 72,
+    topHolders: [
+      { address: 'Holder1', share: 35 },
+      { address: 'Holder2', share: 20 },
+      { address: 'Holder3', share: 15 },
+    ],
+    properties: {
+      mintable: true,
+      mutable: false,
+      authority: 'ExampleAuthority',
+    },
+    critical: false,
+  });
+});
+
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Server running on ${PORT}`));


### PR DESCRIPTION
## Summary
- add `/api/security` endpoint serving mock contract security data
- create new `Security` page in React client to show security score, top holders, and contract properties
- link Security page in the app navigation
- document new endpoint and page in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68455833f9c0832eb4ac8e492e57e120