### PR TITLE
Add whale tracking page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ npm start
 ```
 
 This starts an Express server on port 3001 and exposes `/api/prices?token=<address>`.
+Additional endpoints for whale tracking include:
+
+* `GET /api/whales` - recent whale transactions
+* `GET /api/whales/tracked` and `POST /api/whales/tracked` - manage tracked addresses
+* `GET /api/whales/alerts` and `POST /api/whales/alerts` - configure whale alerts
 
 ### Client
 
@@ -23,3 +28,5 @@ npm run dev
 ```
 
 Open `http://localhost:5173` to view the React app.
+The UI now includes a **Whales** page where you can view recent whale transactions,
+track specific addresses and configure whale alerts.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Whales from './pages/Whales';
 import './App.css';
 
 function App() {
@@ -12,13 +13,15 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/whales">Whales</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/whales" element={<Whales />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/Whales.tsx
+++ b/client/src/pages/Whales.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+
+interface WhaleTransaction {
+  id: number;
+  address: string;
+  token: string;
+  amount: number;
+  timestamp: string;
+}
+
+interface WhaleAlert {
+  address: string;
+  token: string;
+  amount: number;
+}
+
+export default function Whales() {
+  const [transactions, setTransactions] = useState<WhaleTransaction[]>([]);
+  const [tracked, setTracked] = useState<string[]>([]);
+  const [alerts, setAlerts] = useState<WhaleAlert[]>([]);
+
+  const [newAddress, setNewAddress] = useState('');
+  const [alertAddress, setAlertAddress] = useState('');
+  const [alertToken, setAlertToken] = useState('');
+  const [alertAmount, setAlertAmount] = useState('');
+
+  useEffect(() => {
+    fetch('http://localhost:3001/api/whales')
+      .then(res => res.json())
+      .then(json => setTransactions(json.transactions || []))
+      .catch(console.error);
+
+    fetch('http://localhost:3001/api/whales/tracked')
+      .then(res => res.json())
+      .then(json => setTracked(json.tracked || []))
+      .catch(console.error);
+
+    fetch('http://localhost:3001/api/whales/alerts')
+      .then(res => res.json())
+      .then(json => setAlerts(json.alerts || []))
+      .catch(console.error);
+  }, []);
+
+  const addAddress = () => {
+    fetch('http://localhost:3001/api/whales/tracked', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address: newAddress }),
+    })
+      .then(res => res.json())
+      .then(json => {
+        setTracked(json.tracked || []);
+        setNewAddress('');
+      })
+      .catch(console.error);
+  };
+
+  const addAlert = () => {
+    fetch('http://localhost:3001/api/whales/alerts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        address: alertAddress,
+        token: alertToken,
+        amount: Number(alertAmount),
+      }),
+    })
+      .then(res => res.json())
+      .then(json => {
+        setAlerts(json.alerts || []);
+        setAlertAddress('');
+        setAlertToken('');
+        setAlertAmount('');
+      })
+      .catch(console.error);
+  };
+
+  return (
+    <div>
+      <h2>Whale Tracker</h2>
+
+      <section>
+        <h3>Recent Whale Transactions</h3>
+        <ul>
+          {transactions.map(tx => (
+            <li key={tx.id}>
+              {tx.address} &ndash; {tx.token} {tx.amount} ({new Date(tx.timestamp).toLocaleString()})
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h3>Tracked Addresses</h3>
+        <ul>
+          {tracked.map(addr => (
+            <li key={addr}>{addr}</li>
+          ))}
+        </ul>
+        <input
+          value={newAddress}
+          onChange={e => setNewAddress(e.target.value)}
+          placeholder="Whale address"
+        />
+        <button onClick={addAddress}>Track Address</button>
+      </section>
+
+      <section>
+        <h3>Whale Alerts</h3>
+        <ul>
+          {alerts.map((a, i) => (
+            <li key={i}>
+              {a.address} &ndash; {a.token} over {a.amount}
+            </li>
+          ))}
+        </ul>
+        <input
+          value={alertAddress}
+          onChange={e => setAlertAddress(e.target.value)}
+          placeholder="Address"
+        />
+        <input
+          value={alertToken}
+          onChange={e => setAlertToken(e.target.value)}
+          placeholder="Token"
+        />
+        <input
+          type="number"
+          value={alertAmount}
+          onChange={e => setAlertAmount(e.target.value)}
+          placeholder="Amount"
+        />
+        <button onClick={addAlert}>Add Alert</button>
+      </section>
+    </div>
+  );
+}

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,27 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// In-memory data for whale transactions, tracked addresses and alerts
+const whaleTransactions = [
+  {
+    id: 1,
+    address: 'WhaleAddress1',
+    token: 'SOL',
+    amount: 100000,
+    timestamp: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    address: 'WhaleAddress2',
+    token: 'USDC',
+    amount: 500000,
+    timestamp: new Date().toISOString(),
+  },
+];
+
+const trackedAddresses = [];
+const whaleAlerts = [];
+
 // Simple health endpoint
 app.get('/', (req, res) => {
   res.json({ status: 'ok' });
@@ -22,6 +43,37 @@ app.get('/api/prices', async (req, res) => {
     console.error(err);
     res.status(500).json({ error: 'Failed to fetch price data' });
   }
+});
+
+// Endpoint to retrieve recent whale transactions
+app.get('/api/whales', (req, res) => {
+  res.json({ transactions: whaleTransactions });
+});
+
+// Get currently tracked whale addresses
+app.get('/api/whales/tracked', (req, res) => {
+  res.json({ tracked: trackedAddresses });
+});
+
+// Add a new whale address to track
+app.post('/api/whales/tracked', (req, res) => {
+  const { address } = req.body;
+  if (address && !trackedAddresses.includes(address)) {
+    trackedAddresses.push(address);
+  }
+  res.json({ tracked: trackedAddresses });
+});
+
+// Get configured whale alerts
+app.get('/api/whales/alerts', (req, res) => {
+  res.json({ alerts: whaleAlerts });
+});
+
+// Add a new whale alert
+app.post('/api/whales/alerts', (req, res) => {
+  const { address, token, amount } = req.body;
+  whaleAlerts.push({ address, token, amount });
+  res.json({ alerts: whaleAlerts });
 });
 
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- create Whales page in the client
- expose server endpoints for whale tracking data
- link Whales page in the UI
- document new API endpoints and page in README

## Testing
- `npm run lint` in `client`
- `npm test` in `client` *(fails: Missing script)*
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in repo root *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68455839aeb0832e95c9aadf77444072