### PR TITLE
Add user profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ npm run dev
 ```
 
 Open `http://localhost:5173` to view the React app.
+
+The navigation bar now includes a **Perfil** link where you can customize your alias, avatar,
+visualize performance statistics and badges, and ajustar configuración de idioma,
+moneda preferida y seguridad 2FA.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Profile from './pages/Profile';
 import './App.css';
 
 function App() {
@@ -12,13 +13,15 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/profile">Perfil</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/profile" element={<Profile />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/Profile.css
+++ b/client/src/pages/Profile.css
@@ -1,0 +1,14 @@
+.profile {
+  text-align: left;
+}
+.profile-section {
+  margin-bottom: 1.5rem;
+}
+.avatar {
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+  margin-top: 0.5rem;
+}

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import './Profile.css';
+
+interface Settings {
+  alias: string;
+  avatar: string; // base64 image string
+  language: string;
+  currency: string;
+  twofa: boolean;
+}
+
+export default function Profile() {
+  const [settings, setSettings] = useState<Settings>({
+    alias: '',
+    avatar: '',
+    language: 'es',
+    currency: 'USD',
+    twofa: false,
+  });
+
+  useEffect(() => {
+    const stored = localStorage.getItem('profile');
+    if (stored) {
+      setSettings(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('profile', JSON.stringify(settings));
+  }, [settings]);
+
+  const handleAvatar = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setSettings({ ...settings, avatar: reader.result as string });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className="profile">
+      <h2>Perfil de Usuario</h2>
+      <div className="profile-section">
+        <label>
+          Alias:
+          <input
+            value={settings.alias}
+            onChange={e => setSettings({ ...settings, alias: e.target.value })}
+          />
+        </label>
+        <label>
+          Avatar:
+          <input type="file" accept="image/*" onChange={handleAvatar} />
+        </label>
+        {settings.avatar && (
+          <img src={settings.avatar} alt="avatar" className="avatar" />
+        )}
+      </div>
+
+      <div className="profile-section">
+        <h3>Estadísticas</h3>
+        <p>Operaciones totales: 0</p>
+        <p>Volumen (placeholder): 0</p>
+      </div>
+
+      <div className="profile-section">
+        <h3>Logros</h3>
+        <ul>
+          <li>Explorador Inicial</li>
+          <li>Primer Swap</li>
+        </ul>
+      </div>
+
+      <div className="profile-section">
+        <h3>Configuración</h3>
+        <label>
+          Idioma:
+          <select
+            value={settings.language}
+            onChange={e => setSettings({ ...settings, language: e.target.value })}
+          >
+            <option value="es">Español</option>
+            <option value="en">English</option>
+          </select>
+        </label>
+        <label>
+          Moneda preferida:
+          <select
+            value={settings.currency}
+            onChange={e => setSettings({ ...settings, currency: e.target.value })}
+          >
+            <option value="USD">USD</option>
+            <option value="EUR">EUR</option>
+          </select>
+        </label>
+        <label>
+          Seguridad adicional (2FA):
+          <input
+            type="checkbox"
+            checked={settings.twofa}
+            onChange={e => setSettings({ ...settings, twofa: e.target.checked })}
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement new profile page with alias, avatar, stats, badges and settings
- add route and link to profile in navigation
- document profile page in README

## Testing
- `npm --prefix client run lint`
- `npm --prefix client run build`
- `npm --prefix server test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845583e6608832e81e8750ea48ca40e