### PR TITLE
Add leaderboard and events pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,8 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Leaderboard from './pages/Leaderboard';
+import Events from './pages/Events';
 import './App.css';
 
 function App() {
@@ -12,13 +14,17 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/leaderboard">Leaderboard</Link> |{' '}
+        <Link to="/events">Events</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/leaderboard" element={<Leaderboard />} />
+        <Route path="/events" element={<Events />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/Events.tsx
+++ b/client/src/pages/Events.tsx
@@ -1,0 +1,17 @@
+export default function Events() {
+  return (
+    <div>
+      <h2>Upcoming Events</h2>
+      <ul>
+        <li>
+          <h3>Monthly Trading Tournament</h3>
+          <p>Compete with others to earn rewards.</p>
+        </li>
+        <li>
+          <h3>Sniper Challenge</h3>
+          <p>Test your speed on new listings.</p>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/client/src/pages/Leaderboard.css
+++ b/client/src/pages/Leaderboard.css
@@ -1,0 +1,30 @@
+.tabs {
+  margin-bottom: 1rem;
+}
+
+.tabs button {
+  margin-right: 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.tabs .active {
+  background-color: #646cff;
+  color: white;
+}
+
+.board-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+.board-table th,
+.board-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+.achievements ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+}

--- a/client/src/pages/Leaderboard.tsx
+++ b/client/src/pages/Leaderboard.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import './Leaderboard.css';
+
+export default function Leaderboard() {
+  const tabs = ['Top Traders', 'Snipers', 'Influencers'];
+  const [activeTab, setActiveTab] = useState(tabs[0]);
+
+  const renderTable = () => (
+    <table className="board-table">
+      <thead>
+        <tr>
+          <th>Rank</th>
+          <th>Name</th>
+          <th>Points</th>
+        </tr>
+      </thead>
+      <tbody>
+        {[1, 2, 3].map(i => (
+          <tr key={i}>
+            <td>{i}</td>
+            <td>Player {i}</td>
+            <td>{1000 - i * 10}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  return (
+    <div>
+      <h2>Leaderboard</h2>
+      <div className="tabs">
+        {tabs.map(tab => (
+          <button
+            key={tab}
+            className={tab === activeTab ? 'active' : ''}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+      <div className="tab-content">{renderTable()}</div>
+      <div className="achievements">
+        <h3>Your Points</h3>
+        <p>1500</p>
+        <h4>Achievements</h4>
+        <ul>
+          <li>First Trade</li>
+          <li>Joined Tournament</li>
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add leaderboard page with tabs for traders, snipers and influencers
- display simple achievements and points system
- add events page listing upcoming tournaments
- link new pages from navigation menu

## Testing
- `npm run lint` within `client`
- `npm test` within `server` *(fails: Error: no test specified)*
- `npm test` within repo root *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684558498b08832e967ec7a012cd486f