### PR TITLE
Add Premium subscription page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Premium from './pages/Premium';
 import './App.css';
 
 function App() {
@@ -12,13 +13,15 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/premium">Premium</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/premium" element={<Premium />} />
       </Routes>
     </Router>
   );

--- a/client/src/pages/Premium.css
+++ b/client/src/pages/Premium.css
@@ -1,0 +1,33 @@
+.premium {
+  text-align: center;
+}
+
+.comparison {
+  margin: 1rem auto;
+  border-collapse: collapse;
+}
+
+.comparison th,
+.comparison td {
+  border: 1px solid #ccc;
+  padding: 0.5rem 1rem;
+}
+
+.plans {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 1rem;
+}
+
+.plan {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  width: 120px;
+}
+
+.benefits {
+  margin-top: 1rem;
+  text-align: left;
+  display: inline-block;
+}

--- a/client/src/pages/Premium.tsx
+++ b/client/src/pages/Premium.tsx
@@ -1,0 +1,66 @@
+import './Premium.css';
+
+export default function Premium() {
+  return (
+    <div className="premium">
+      <h2>Go Premium</h2>
+      <table className="comparison">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th>Free</th>
+            <th>Premium</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Wallet overview</td>
+            <td>✔</td>
+            <td>✔</td>
+          </tr>
+          <tr>
+            <td>Swap tokens</td>
+            <td>✔</td>
+            <td>✔</td>
+          </tr>
+          <tr>
+            <td>Price alerts</td>
+            <td>Up to 3</td>
+            <td>Unlimited</td>
+          </tr>
+          <tr>
+            <td>Advanced analytics</td>
+            <td></td>
+            <td>✔</td>
+          </tr>
+          <tr>
+            <td>Priority support</td>
+            <td></td>
+            <td>✔</td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="plans">
+        <h3>Choose your plan</h3>
+        <div className="plan">
+          <h4>Monthly</h4>
+          <p>$5 / month</p>
+          <button>Subscribe</button>
+        </div>
+        <div className="plan">
+          <h4>Annual</h4>
+          <p>$50 / year</p>
+          <button>Subscribe</button>
+        </div>
+      </div>
+      <div className="benefits">
+        <h3>Premium benefits</h3>
+        <ul>
+          <li>Unlimited price alerts</li>
+          <li>Advanced analytics</li>
+          <li>Priority customer support</li>
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new Premium page comparing Free vs Premium plans
- link Premium page from the site navigation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845584f721c832eace3fc6be9b66b71