### PR TITLE
Add settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ npm run dev
 ```
 
 Open `http://localhost:5173` to view the React app.
+
+### Settings
+
+The client now includes a simple settings page where you can:
+
+- Toggle dark or light mode.
+- Enable or disable biometric/PIN security (placeholder).
+- Control global notifications.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Swap from './pages/Swap';
 import Wallet from './pages/Wallet';
 import Alerts from './pages/Alerts';
+import Settings from './pages/Settings';
 import './App.css';
 
 function App() {
@@ -12,13 +13,15 @@ function App() {
         <Link to="/">Dashboard</Link> |{' '}
         <Link to="/wallet">Wallet</Link> |{' '}
         <Link to="/swap">Swap</Link> |{' '}
-        <Link to="/alerts">Alerts</Link>
+        <Link to="/alerts">Alerts</Link> |{' '}
+        <Link to="/settings">Settings</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/wallet" element={<Wallet />} />
         <Route path="/swap" element={<Swap />} />
         <Route path="/alerts" element={<Alerts />} />
+        <Route path="/settings" element={<Settings />} />
       </Routes>
     </Router>
   );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -30,6 +30,16 @@ body {
   min-height: 100vh;
 }
 
+body.light {
+  color: #213547;
+  background-color: #ffffff;
+}
+
+body.dark {
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+}
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,11 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null
+if (savedTheme === 'dark' || savedTheme === 'light') {
+  document.body.classList.add(savedTheme)
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+
+export default function Settings() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [security, setSecurity] = useState(false);
+  const [notifications, setNotifications] = useState(true);
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark' || savedTheme === 'light') {
+      setTheme(savedTheme);
+      document.body.classList.remove('light', 'dark');
+      document.body.classList.add(savedTheme);
+    }
+    const savedSecurity = localStorage.getItem('securityEnabled');
+    if (savedSecurity) {
+      setSecurity(savedSecurity === 'true');
+    }
+    const savedNotifications = localStorage.getItem('notificationsEnabled');
+    if (savedNotifications) {
+      setNotifications(savedNotifications === 'true');
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+    document.body.classList.remove('light', 'dark');
+    document.body.classList.add(newTheme);
+  };
+
+  const toggleSecurity = () => {
+    const newValue = !security;
+    setSecurity(newValue);
+    localStorage.setItem('securityEnabled', String(newValue));
+  };
+
+  const toggleNotifications = () => {
+    const newValue = !notifications;
+    setNotifications(newValue);
+    localStorage.setItem('notificationsEnabled', String(newValue));
+  };
+
+  return (
+    <div>
+      <h2>Configuración General</h2>
+      <div>
+        <label>
+          Modo oscuro:
+          <input type="checkbox" checked={theme === 'dark'} onChange={toggleTheme} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Seguridad biométrica/PIN:
+          <input type="checkbox" checked={security} onChange={toggleSecurity} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Notificaciones globales:
+          <input type="checkbox" checked={notifications} onChange={toggleNotifications} />
+        </label>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Settings page with theme, security and notification toggles
- hook up the new Settings route and navigation link
- persist and apply theme choice on load
- style light/dark themes
- document the new settings page in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations and packages)*

------
https://chatgpt.com/codex/tasks/task_e_68455855366c832eb373498480982e60