### PR TITLE
Remove express from devDeps

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-
         "express": "^5.1.0",
         "node-fetch": "^3.3.2"
       },
@@ -2309,9 +2308,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-
-        "express": "^5.1.0"
-
       }
     },
     "node_modules/get-stream": {
@@ -3601,7 +3597,6 @@
         "node": ">=10.5.0"
       }
     },
-
     "node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -3657,7 +3652,6 @@
         "node": ">=8"
       }
     },
-
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "jest": "^29.0.0",
-    "supertest": "^6.3.3",
-    "express": "^5.1.0"
+    "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- delete express from `server/package.json` devDependencies
- update `server/package-lock.json` via `npm install`

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684664b2884c832e9de461182d949869