### PR TITLE
Fix index.js server start

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,3 @@ if (require.main === module) {
 }
 
 module.exports = app;
-app.listen(PORT, () => {
-  console.log(`Server running on ${PORT}`);
-});


### PR DESCRIPTION
## Summary
- avoid starting the Express server when `index.js` is imported by tests

## Testing
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_6846727d85a4832ea6530f607e942a7f