### PR TITLE
Add auth & wallet setup routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,8 +22,15 @@ import SmartOrders from 'pages/SmartOrders';
 import CopyTrading from 'pages/CopyTrading';
 import Sniping from 'pages/Sniping';
 
-
 import History from 'pages/History';
+import Login from 'pages/Login';
+import Register from 'pages/Register';
+import Onboarding from 'pages/Onboarding';
+import WalletSetup from 'pages/WalletSetup';
+import SeedPhrase from 'pages/SeedPhrase';
+import ConfirmSeed from 'pages/ConfirmSeed';
+import Send from 'pages/Send';
+import Receive from 'pages/Receive';
 import BottomNav from 'components/BottomNav';
 
 
@@ -39,7 +46,15 @@ function App() {
         <Link to="/swap">Swap</Link> |{' '}
         <Link to="/alerts">Alerts</Link> |{' '}
         <Link to="/education">Educación</Link> |{' '}
-        <Link to="/faq">FAQ</Link>
+        <Link to="/faq">FAQ</Link> |{' '}
+        <Link to="/login">Login</Link> |{' '}
+        <Link to="/register">Register</Link> |{' '}
+        <Link to="/onboarding">Onboarding</Link> |{' '}
+        <Link to="/wallet-setup">WalletSetup</Link> |{' '}
+        <Link to="/seed-phrase">SeedPhrase</Link> |{' '}
+        <Link to="/confirm-seed">ConfirmSeed</Link> |{' '}
+        <Link to="/send">Send</Link> |{' '}
+        <Link to="/receive">Receive</Link>
         <Link to="/settings">Settings</Link>
 
         <Link to="/premium">Premium</Link>
@@ -64,6 +79,14 @@ function App() {
         <Route path="/alerts" element={<Alerts />} />
         <Route path="/education" element={<Education />} />
         <Route path="/faq" element={<FAQ />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="/onboarding" element={<Onboarding />} />
+        <Route path="/wallet-setup" element={<WalletSetup />} />
+        <Route path="/seed-phrase" element={<SeedPhrase />} />
+        <Route path="/confirm-seed" element={<ConfirmSeed />} />
+        <Route path="/send" element={<Send />} />
+        <Route path="/receive" element={<Receive />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/premium" element={<Premium />} />
         <Route path="/leaderboard" element={<Leaderboard />} />

--- a/client/src/components/BottomNav.tsx
+++ b/client/src/components/BottomNav.tsx
@@ -11,6 +11,8 @@ export default function BottomNav() {
       <Link to="/" className={isActive('/') ? 'active' : ''}>🏠</Link>
       <Link to="/swap" className={isActive('/swap') ? 'active' : ''}>📈</Link>
       <Link to="/wallet" className={isActive('/wallet') ? 'active' : ''}>👛</Link>
+      <Link to="/send" className={isActive('/send') ? 'active' : ''}>⬆️</Link>
+      <Link to="/receive" className={isActive('/receive') ? 'active' : ''}>⬇️</Link>
       <Link to="/alerts" className={isActive('/alerts') ? 'active' : ''}>🔔</Link>
       <Link to="/profile" className={isActive('/profile') ? 'active' : ''}>👤</Link>
     </nav>


### PR DESCRIPTION
## Summary
- register new routes for Login, Register, Onboarding and wallet setup pages
- expose Send and Receive routes
- show links in the main nav
- update BottomNav with Send and Receive icons

## Testing
- `npm --prefix client test` *(fails: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', or 'nodenext')*


------
https://chatgpt.com/codex/tasks/task_e_68467285adf4832e880c794db328f1e2