### PR TITLE
Use RPC URL from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A minimal prototype implementing Phase 1 of the ScreenerWallet roadmap.
 - npm 9 or later
 - Run `npm install` in both the `server` and `client` directories
 
-
 ## Getting Started
 
 ### Server
@@ -94,8 +93,9 @@ Create a `.env` file inside the `client` directory and set the following values:
 VITE_RPC_URL=https://your.solana.rpc/url
 VITE_API_URL=http://localhost:3001
 ```
+
 Vite exposes variables prefixed with `VITE_` to the client application.
-`VITE_RPC_URL` is required for Solana RPC calls.
+`VITE_RPC_URL` defines the Solana RPC endpoint used by pages like **Send** and **Swap**.
 `VITE_API_URL` defines the base URL for API requests (default `http://localhost:3001`).
 
 ### Testing

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,4 @@
+# RPC endpoint for Solana calls
 VITE_RPC_URL=https://your.solana.rpc/url
+# Base URL for the Express API
 VITE_API_URL=http://localhost:3001

--- a/client/src/pages/Send.tsx
+++ b/client/src/pages/Send.tsx
@@ -1,44 +1,45 @@
-import { useEffect, useState } from 'react';
-import { Connection, PublicKey } from '@solana/web3.js';
+import { useEffect, useState } from 'react'
+import { Connection, PublicKey } from '@solana/web3.js'
 
 export default function Send() {
-  const [token, setToken] = useState('SOL');
-  const [balance, setBalance] = useState<number | null>(null);
-  const [to, setTo] = useState('');
-  const [amount, setAmount] = useState('');
-  const [usdValue, setUsdValue] = useState('');
-  const [confirm, setConfirm] = useState(false);
+  const [token, setToken] = useState('SOL')
+  const [balance, setBalance] = useState<number | null>(null)
+  const [to, setTo] = useState('')
+  const [amount, setAmount] = useState('')
+  const [usdValue, setUsdValue] = useState('')
+  const [confirm, setConfirm] = useState(false)
 
   useEffect(() => {
-    const key = localStorage.getItem('wallet');
+    const key = localStorage.getItem('wallet')
     if (key) {
-      const connection = new Connection('https://api.mainnet-beta.solana.com');
+      const rpcUrl = import.meta.env.VITE_RPC_URL
+      const connection = new Connection(rpcUrl)
       connection.getBalance(new PublicKey(key)).then((lamports: number) => {
-        setBalance(lamports / 1e9);
-      });
+        setBalance(lamports / 1e9)
+      })
     }
-  }, []);
+  }, [])
 
   useEffect(() => {
     if (amount) {
       fetch(`${import.meta.env.VITE_API_URL}/api/prices?token=solana`)
-        .then(res => res.json())
-        .then(json => {
-          const price = json.pairs ? parseFloat(json.pairs[0].priceUsd) : 0;
-          setUsdValue((parseFloat(amount) * price).toFixed(2));
+        .then((res) => res.json())
+        .then((json) => {
+          const price = json.pairs ? parseFloat(json.pairs[0].priceUsd) : 0
+          setUsdValue((parseFloat(amount) * price).toFixed(2))
         })
-        .catch(() => setUsdValue('0'));
+        .catch(() => setUsdValue('0'))
     } else {
-      setUsdValue('');
+      setUsdValue('')
     }
-  }, [amount]);
+  }, [amount])
 
   const handleSend = () => {
-    alert(`Sent ${amount} ${token} to ${to} (placeholder)`);
-    setConfirm(false);
-    setTo('');
-    setAmount('');
-  };
+    alert(`Sent ${amount} ${token} to ${to} (placeholder)`)
+    setConfirm(false)
+    setTo('')
+    setAmount('')
+  }
 
   return (
     <div>
@@ -46,7 +47,7 @@ export default function Send() {
       <div>
         <label>
           Token:
-          <select value={token} onChange={e => setToken(e.target.value)}>
+          <select value={token} onChange={(e) => setToken(e.target.value)}>
             <option value="SOL">SOL</option>
             <option value="USDC">USDC</option>
           </select>
@@ -58,7 +59,7 @@ export default function Send() {
           Dirección destino:
           <input
             value={to}
-            onChange={e => setTo(e.target.value)}
+            onChange={(e) => setTo(e.target.value)}
             placeholder="Ingresar dirección"
           />
           <button type="button">Escanear QR</button>
@@ -69,7 +70,7 @@ export default function Send() {
           Cantidad:
           <input
             value={amount}
-            onChange={e => setAmount(e.target.value)}
+            onChange={(e) => setAmount(e.target.value)}
             placeholder="0.0"
           />
           {usdValue && <span> (${usdValue} USD)</span>}
@@ -98,5 +99,5 @@ export default function Send() {
         </button>
       )}
     </div>
-  );
+  )
 }

--- a/client/src/pages/Swap.tsx
+++ b/client/src/pages/Swap.tsx
@@ -1,62 +1,61 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react'
 
 export default function Swap() {
-  const [fromToken, setFromToken] = useState('SOL');
-  const [toToken, setToToken] = useState('USDC');
-  const [fromAmount, setFromAmount] = useState('');
-  const [toAmount, setToAmount] = useState('');
-  const [usdValue, setUsdValue] = useState('');
-  const [route] = useState<'Orca' | 'Raydium'>('Orca');
-  const [balance, setBalance] = useState<number | null>(null);
-  const [slippage] = useState(0.5);
-  const [fee] = useState(0.000005);
-  const [confirm, setConfirm] = useState(false);
-  const [swapped, setSwapped] = useState(false);
-  const [txId, setTxId] = useState('');
+  const [fromToken, setFromToken] = useState('SOL')
+  const [toToken, setToToken] = useState('USDC')
+  const [fromAmount, setFromAmount] = useState('')
+  const [toAmount, setToAmount] = useState('')
+  const [usdValue, setUsdValue] = useState('')
+  const [route] = useState<'Orca' | 'Raydium'>('Orca')
+  const [balance, setBalance] = useState<number | null>(null)
+  const [slippage] = useState(0.5)
+  const [fee] = useState(0.000005)
+  const [confirm, setConfirm] = useState(false)
+  const [swapped, setSwapped] = useState(false)
+  const [txId, setTxId] = useState('')
 
   useEffect(() => {
-    const key = localStorage.getItem('wallet');
+    const key = localStorage.getItem('wallet')
     if (key && fromToken === 'SOL') {
       import('@solana/web3.js')
         .then(({ Connection, PublicKey }) => {
-          const connection = new Connection(
-            'https://api.mainnet-beta.solana.com'
-          );
+          const rpcUrl = import.meta.env.VITE_RPC_URL
+          const connection = new Connection(rpcUrl)
           connection.getBalance(new PublicKey(key)).then((lamports: number) => {
-            setBalance(lamports / 1e9);
-          });
+            setBalance(lamports / 1e9)
+          })
         })
-        .catch(() => setBalance(null));
+        .catch(() => setBalance(null))
     } else {
-      setBalance(null);
+      setBalance(null)
     }
-  }, [fromToken]);
+  }, [fromToken])
 
   useEffect(() => {
     if (fromAmount) {
-      const token = fromToken === 'SOL' ? 'solana' : fromToken.toLowerCase();
+      const token = fromToken === 'SOL' ? 'solana' : fromToken.toLowerCase()
       fetch(`${import.meta.env.VITE_API_URL}/api/prices?token=${token}`)
-        .then(res => res.json())
-        .then(json => {
-          const price = json.pairs ? parseFloat(json.pairs[0].priceUsd) : 0;
-          setUsdValue((parseFloat(fromAmount) * price).toFixed(2));
-          setToAmount(fromAmount);
+        .then((res) => res.json())
+        .then((json) => {
+          const price = json.pairs ? parseFloat(json.pairs[0].priceUsd) : 0
+          setUsdValue((parseFloat(fromAmount) * price).toFixed(2))
+          setToAmount(fromAmount)
         })
         .catch(() => {
-          setUsdValue('0');
-          setToAmount(fromAmount);
-        });
+          setUsdValue('0')
+          setToAmount(fromAmount)
+        })
     } else {
-      setUsdValue('');
-      setToAmount('');
+      setUsdValue('')
+      setToAmount('')
     }
-  }, [fromAmount, fromToken]);
+  }, [fromAmount, fromToken])
 
   const handleConfirm = () => {
-    setConfirm(false);
-    setSwapped(true);
-    setTxId(Math.random().toString(36).substring(2, 10).toUpperCase());
-  };
+    setConfirm(false)
+    setSwapped(true)
+    setTxId(Math.random().toString(36).substring(2, 10).toUpperCase())
+  }
 
   if (swapped) {
     return (
@@ -69,7 +68,7 @@ export default function Swap() {
         <p>Fee: {fee} SOL</p>
         <p>TX ID: {txId}</p>
       </div>
-    );
+    )
   }
 
   return (
@@ -80,7 +79,7 @@ export default function Swap() {
           Token origen:
           <select
             value={fromToken}
-            onChange={e => setFromToken(e.target.value)}
+            onChange={(e) => setFromToken(e.target.value)}
           >
             <option value="SOL">SOL</option>
             <option value="USDC">USDC</option>
@@ -93,7 +92,7 @@ export default function Swap() {
           Cantidad:
           <input
             value={fromAmount}
-            onChange={e => setFromAmount(e.target.value)}
+            onChange={(e) => setFromAmount(e.target.value)}
             placeholder="0.0"
           />
         </label>
@@ -102,7 +101,7 @@ export default function Swap() {
       <div style={{ marginBottom: '1rem' }}>
         <label>
           Token destino:
-          <select value={toToken} onChange={e => setToToken(e.target.value)}>
+          <select value={toToken} onChange={(e) => setToToken(e.target.value)}>
             <option value="USDC">USDC</option>
             <option value="SOL">SOL</option>
           </select>
@@ -166,6 +165,5 @@ export default function Swap() {
         </button>
       )}
     </div>
-  );
+  )
 }
-


### PR DESCRIPTION
## Summary
- use `VITE_RPC_URL` when creating `Connection` instances
- document the variable in README
- add comments in `.env.example`

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix server test` *(fails: jest not found)*
- `npm --prefix client test` *(fails: jest not found)*
- `npx prettier --check README.md client/.env.example client/src/pages/Send.tsx client/src/pages/Swap.tsx --ignore-unknown`

------
https://chatgpt.com/codex/tasks/task_e_6846728ba854832e8565e11689209ca3