### PR TITLE
Add tests for security and whale tracking endpoints

### DIFF
--- a/server/tests/security.test.js
+++ b/server/tests/security.test.js
@@ -1,0 +1,20 @@
+const request = require('supertest');
+
+let app;
+
+beforeEach(() => {
+  jest.resetModules();
+  app = require('../index');
+});
+
+describe('/api/security', () => {
+  it('returns mock security info for a token', async () => {
+    const res = await request(app).get('/api/security?token=TEST');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBe('TEST');
+    expect(res.body).toHaveProperty('score', 72);
+    expect(Array.isArray(res.body.topHolders)).toBe(true);
+    expect(res.body).toHaveProperty('properties');
+    expect(res.body).toHaveProperty('critical', false);
+  });
+});

--- a/server/tests/whales.tracking.test.js
+++ b/server/tests/whales.tracking.test.js
@@ -1,0 +1,33 @@
+const request = require('supertest');
+
+let app;
+
+beforeEach(() => {
+  jest.resetModules();
+  app = require('../index');
+});
+
+describe('whale tracking endpoints', () => {
+  it('adds and retrieves tracked addresses', async () => {
+    const trackRes = await request(app)
+      .post('/api/whales/tracked')
+      .send({ address: 'WhaleA' });
+    expect(trackRes.statusCode).toBe(200);
+    expect(trackRes.body.tracked).toContain('WhaleA');
+
+    const getRes = await request(app).get('/api/whales/tracked');
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.body.tracked).toContain('WhaleA');
+  });
+
+  it('adds and retrieves whale alerts', async () => {
+    const alert = { address: 'WhaleB', token: 'SOL', amount: 500 };
+    const post = await request(app).post('/api/whales/alerts').send(alert);
+    expect(post.statusCode).toBe(200);
+    expect(post.body.alerts).toEqual([alert]);
+
+    const get = await request(app).get('/api/whales/alerts');
+    expect(get.statusCode).toBe(200);
+    expect(get.body.alerts).toEqual([alert]);
+  });
+});


### PR DESCRIPTION
## Summary
- test `/api/security` endpoint
- test whale tracking GET endpoints after creating entries

## Testing
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_6846728f1f50832eaf6bc5fc85a48012