### PR TITLE
Add API security and whale tracking tests

### DIFF
--- a/server/tests/security.test.js
+++ b/server/tests/security.test.js
@@ -1,0 +1,19 @@
+const request = require('supertest');
+
+let app;
+
+beforeEach(() => {
+  jest.resetModules();
+  app = require('../index');
+});
+
+describe('/api/security', () => {
+  it('returns mock security data for a token', async () => {
+    const res = await request(app).get('/api/security?token=SOL');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('token', 'SOL');
+    expect(res.body).toHaveProperty('score');
+    expect(Array.isArray(res.body.topHolders)).toBe(true);
+    expect(res.body).toHaveProperty('properties');
+  });
+});

--- a/server/tests/whales.test.js
+++ b/server/tests/whales.test.js
@@ -31,4 +31,24 @@ describe('/api/whales', () => {
       { address: 'WhaleX', token: 'SOL', amount: 1000 },
     ]);
   });
+
+  it('retrieves tracked addresses and alerts', async () => {
+    await request(app)
+      .post('/api/whales/tracked')
+      .send({ address: 'WhaleY' });
+
+    const trackedRes = await request(app).get('/api/whales/tracked');
+    expect(trackedRes.statusCode).toBe(200);
+    expect(trackedRes.body.tracked).toContain('WhaleY');
+
+    await request(app)
+      .post('/api/whales/alerts')
+      .send({ address: 'WhaleY', token: 'SOL', amount: 2000 });
+
+    const alertsRes = await request(app).get('/api/whales/alerts');
+    expect(alertsRes.statusCode).toBe(200);
+    expect(alertsRes.body.alerts).toEqual([
+      { address: 'WhaleY', token: 'SOL', amount: 2000 },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for `/api/security`
- extend whale tracking tests to cover GET endpoints

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68467292a99c832eabeecbe2558cf599