### PR TITLE
Add NotFound page and catch-all route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,6 +24,7 @@ import Sniping from 'pages/Sniping';
 
 
 import History from 'pages/History';
+import NotFound from 'pages/NotFound';
 import BottomNav from 'components/BottomNav';
 
 
@@ -83,6 +84,7 @@ function App() {
         <Route path="/sniping" element={<Sniping />} />
 
         <Route path="/history" element={<History />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
       <BottomNav />
     </Router>

--- a/client/src/pages/NotFound.tsx
+++ b/client/src/pages/NotFound.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div style={{ paddingBottom: '80px', textAlign: 'center' }}>
+      <h2>Page Not Found</h2>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create NotFound page
- add catch-all route in App

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467295e368832e9682873e3359af29