### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install root dependencies
+        run: npm install
+      - name: Install server dependencies
+        run: npm install
+        working-directory: server
+      - name: Install client dependencies
+        run: npm install --legacy-peer-deps
+        working-directory: client
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test
+      - name: Build server
+        run: npm --prefix server run build
+      - name: Build client
+        run: npm --prefix client run build
+

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ You can also run `npm test` inside each subdirectory to execute them individuall
 Vite exposes variables prefixed with `VITE_` to the client application. These
 values are required for network requests performed by the wallet screen.
 
+### Continuous Integration
+
+Pull requests trigger a GitHub Actions workflow defined in `.github/workflows/ci.yml`.
+The workflow installs dependencies, runs `npm test` and `npm run lint`, and then
+builds both the server and client.
+
 ## Contributing
 
 Install dependencies in the root, server and client folders before working on the project:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "scripts": {
     "test": "npm --prefix server test && npm --prefix client test",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "lint": "npm --prefix client run lint",
+    "build": "npm --prefix server run build && npm --prefix client run build"
   },
   "lint-staged": {
     "*": "prettier --check"

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "start": "node index.js"
+    "start": "node index.js",
+    "build": "echo \"building server\""
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to test, lint and build
- expose `lint` and `build` npm scripts
- add a placeholder `build` script in the server
- mention the workflow in the README

## Testing
- `npm test` *(fails: TypeScript config errors)*
- `npm run lint`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684672986b98832e8d1e1f1cdcc40286