### PR TITLE
Expose VITE vars in Vite config

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,8 +1,8 @@
 
-# RPC endpoint for Solana calls
-
 # Example client environment file
 
-VITE_RPC_URL=https://your.solana.rpc/url
 # Base URL for the Express API
 VITE_API_URL=http://localhost:3001
+
+# RPC endpoint for Solana calls
+VITE_SOLANA_RPC=https://your.solana.rpc/url

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // Make all environment variables starting with "VITE_" available to the
+  // client-side code.
+  envPrefix: 'VITE_',
 })


### PR DESCRIPTION
## Summary
- expose env variables starting with `VITE_` to the client
- document `VITE_API_URL` and `VITE_SOLANA_RPC` in `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684767a6b158832eaf99482b6b2fca1c