### PR TITLE
Add wallet context and hook

### DIFF
--- a/client/src/context/WalletContext.tsx
+++ b/client/src/context/WalletContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, ReactNode } from 'react'
+import useWallet, { WalletState } from '../hooks/useWallet'
+
+const WalletContext = createContext<WalletState | undefined>(undefined)
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const wallet = useWallet()
+  return <WalletContext.Provider value={wallet}>{children}</WalletContext.Provider>
+}
+
+export function useWalletContext(): WalletState {
+  const ctx = useContext(WalletContext)
+  if (!ctx) {
+    throw new Error('useWalletContext must be used within WalletProvider')
+  }
+  return ctx
+}
+
+export default WalletContext

--- a/client/src/hooks/useWallet.ts
+++ b/client/src/hooks/useWallet.ts
@@ -1,0 +1,50 @@
+import { Connection, PublicKey, Keypair } from '@solana/web3.js'
+import { useCallback, useEffect, useState } from 'react'
+
+export interface WalletState {
+  publicKey: string | null
+  balance: number | null
+  connect: () => Promise<void>
+  disconnect: () => void
+}
+
+export default function useWallet(): WalletState {
+  const [publicKey, setPublicKey] = useState<string | null>(null)
+  const [balance, setBalance] = useState<number | null>(null)
+  const rpcUrl = import.meta.env.VITE_RPC_URL
+
+  const connect = useCallback(async () => {
+    let key = localStorage.getItem('wallet')
+    if (!key) {
+      const kp = Keypair.generate()
+      key = kp.publicKey.toBase58()
+      localStorage.setItem('wallet', key)
+    }
+    setPublicKey(key)
+  }, [])
+
+  const disconnect = useCallback(() => {
+    localStorage.removeItem('wallet')
+    setPublicKey(null)
+    setBalance(null)
+  }, [])
+
+  useEffect(() => {
+    const saved = localStorage.getItem('wallet')
+    if (saved) setPublicKey(saved)
+  }, [])
+
+  useEffect(() => {
+    if (publicKey) {
+      const connection = new Connection(rpcUrl)
+      connection
+        .getBalance(new PublicKey(publicKey))
+        .then((lamports) => setBalance(lamports / 1e9))
+        .catch(() => setBalance(null))
+    } else {
+      setBalance(null)
+    }
+  }, [publicKey, rpcUrl])
+
+  return { publicKey, balance, connect, disconnect }
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { WalletProvider } from './context/WalletContext'
 
 const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null
 if (savedTheme === 'dark' || savedTheme === 'light') {
@@ -10,6 +11,8 @@ if (savedTheme === 'dark' || savedTheme === 'light') {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <WalletProvider>
+      <App />
+    </WalletProvider>
   </StrictMode>,
 )

--- a/client/src/pages/Wallet.tsx
+++ b/client/src/pages/Wallet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useWalletContext } from '../context/WalletContext';
 import './Dashboard.css';
 
 interface WalletToken {
@@ -18,6 +19,7 @@ const tokens: WalletToken[] = [
 
 export default function Wallet() {
   const navigate = useNavigate();
+  const { publicKey, balance, connect, disconnect } = useWalletContext();
   const [solPrice, setSolPrice] = useState<number>(150);
 
   useEffect(() => {
@@ -48,6 +50,17 @@ export default function Wallet() {
           </div>
         </div>
       </div>
+      {publicKey ? (
+        <div style={{ padding: '0.5rem' }}>
+          <p>Conectado: {publicKey}</p>
+          {balance !== null && <p>Saldo: {balance} SOL</p>}
+          <button onClick={disconnect}>Desconectar</button>
+        </div>
+      ) : (
+        <div style={{ padding: '0.5rem' }}>
+          <button onClick={connect}>Conectar wallet</button>
+        </div>
+      )}
       <ul className="token-list">
         {tokens.map(t => (
           <li key={t.symbol}>

--- a/server/tests/security.test.js
+++ b/server/tests/security.test.js
@@ -8,7 +8,6 @@ beforeEach(() => {
 });
 
 describe('/api/security', () => {
-
   it('returns mock security data for a token', async () => {
     const res = await request(app).get('/api/security?token=SOL');
     expect(res.statusCode).toBe(200);
@@ -16,6 +15,7 @@ describe('/api/security', () => {
     expect(res.body).toHaveProperty('score');
     expect(Array.isArray(res.body.topHolders)).toBe(true);
     expect(res.body).toHaveProperty('properties');
+  });
 
   it('returns mock security info for a token', async () => {
     const res = await request(app).get('/api/security?token=TEST');
@@ -25,6 +25,5 @@ describe('/api/security', () => {
     expect(Array.isArray(res.body.topHolders)).toBe(true);
     expect(res.body).toHaveProperty('properties');
     expect(res.body).toHaveProperty('critical', false);
-
   });
 });


### PR DESCRIPTION
## Summary
- implement minimal wallet hook storing key in localStorage and fetching balance
- expose wallet state through a new `WalletContext`
- wrap the app with the provider and show wallet info on the Wallet page
- fix malformed security test

## Testing
- `npm test` *(fails: client tests error on `import.meta` TS compile)*

------
https://chatgpt.com/codex/tasks/task_e_684772e9cdc8832e8d722c3f3520a2e0