### PR TITLE
Add useWallet hook

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,9 +37,6 @@ import ConfirmSeed from 'pages/ConfirmSeed';
 import Send from 'pages/Send';
 import Receive from 'pages/Receive';
 
-import BottomNav from 'components/BottomNav';
-
-
 import './App.css';
 
 function App() {
@@ -68,7 +65,7 @@ function App() {
           <Route path="sniping" element={<Sniping />} />
           <Route path="history" element={<History />} />
         </Route>
-
+      </Routes>
 
       <nav>
         <Link to="/">Dashboard</Link> |{' '}

--- a/client/src/hooks/useWallet.ts
+++ b/client/src/hooks/useWallet.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import { Connection, Keypair } from '@solana/web3.js'
+import { mnemonicToSeedSync } from 'bip39'
+
+const SEED_KEY = 'seed_enc'
+const WALLET_KEY = 'wallet'
+const ENC_KEY = 'screener'
+
+const xor = (text: string, key: string) =>
+  [...text]
+    .map((c, i) => String.fromCharCode(c.charCodeAt(0) ^ key.charCodeAt(i % key.length)))
+    .join('')
+
+const encrypt = (text: string) => btoa(xor(text, ENC_KEY))
+const decrypt = (data: string) => xor(atob(data), ENC_KEY)
+
+export default function useWallet() {
+  const [connection, setConnection] = useState<Connection | null>(null)
+  const [publicKey, setPublicKey] = useState<string | null>(null)
+
+  useEffect(() => {
+    const url = import.meta.env.VITE_SOLANA_RPC
+    if (url) setConnection(new Connection(url))
+  }, [])
+
+  useEffect(() => {
+    const stored = localStorage.getItem(SEED_KEY)
+    if (stored) {
+      try {
+        const phrase = decrypt(stored)
+        const seed = mnemonicToSeedSync(phrase).slice(0, 32)
+        const kp = Keypair.fromSeed(seed)
+        const pk = kp.publicKey.toBase58()
+        localStorage.setItem(WALLET_KEY, pk)
+        setPublicKey(pk)
+      } catch (e) {
+        console.error('Failed to load wallet', e)
+      }
+    }
+  }, [])
+
+  const saveSeed = (phrase: string) => {
+    localStorage.setItem(SEED_KEY, encrypt(phrase))
+    const seed = mnemonicToSeedSync(phrase).slice(0, 32)
+    const kp = Keypair.fromSeed(seed)
+    const pk = kp.publicKey.toBase58()
+    localStorage.setItem(WALLET_KEY, pk)
+    setPublicKey(pk)
+  }
+
+  const disconnect = () => {
+    setConnection(null)
+    setPublicKey(null)
+  }
+
+  return { connection, publicKey, saveSeed, disconnect }
+}

--- a/server/tests/security.test.js
+++ b/server/tests/security.test.js
@@ -16,6 +16,7 @@ describe('/api/security', () => {
     expect(res.body).toHaveProperty('score');
     expect(Array.isArray(res.body.topHolders)).toBe(true);
     expect(res.body).toHaveProperty('properties');
+  });
 
   it('returns mock security info for a token', async () => {
     const res = await request(app).get('/api/security?token=TEST');
@@ -25,6 +26,5 @@ describe('/api/security', () => {
     expect(Array.isArray(res.body.topHolders)).toBe(true);
     expect(res.body).toHaveProperty('properties');
     expect(res.body).toHaveProperty('critical', false);
-
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable `useWallet` hook to connect to Solana RPC
- fix missing JSX closing tag in `App.tsx`
- correct syntax of `server/tests/security.test.js`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684772ecd870832e9cebc5d639e3d230