### PR TITLE
Convert App stylesheet to CSS module

### DIFF
--- a/client/src/App.module.css
+++ b/client/src/App.module.css
@@ -1,4 +1,4 @@
-#root {
+:global(#root) {
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,7 +40,8 @@ import Receive from 'pages/Receive';
 import BottomNav from 'components/BottomNav';
 
 
-import './App.css';
+import styles from './App.module.css';
+void styles;
 
 function App() {
   return (

--- a/client/src/pages/Onboarding.tsx
+++ b/client/src/pages/Onboarding.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import '../App.css';
+import styles from '../App.module.css';
 
 interface Slide {
   title: string;
@@ -43,7 +43,7 @@ export default function Onboarding() {
 
   const slide = slides[index];
   return (
-    <div className="onboarding-slide">
+    <div className={styles['onboarding-slide']}>
       <h2>{slide.title}</h2>
       <p>{slide.text}</p>
       {slide.final ? (


### PR DESCRIPTION
## Summary
- rename `App.css` to `App.module.css`
- switch imports to the new module
- use the module class in Onboarding page
- mark the root selector as global to retain styles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684772faccb4832ead27aaca37988ab4