### PR TITLE
Add copy trading hook and service

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@solana/web3.js": "^1.98.2",
+        "@tanstack/react-query": "^5.80.6",
         "bip39": "^3.0.4",
         "qrcode": "^1.5.1",
         "react": "^19.1.0",
@@ -2782,6 +2783,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.6.tgz",
+      "integrity": "sha512-nl7YxT/TAU+VTf+e2zTkObGTyY8YZBMnbgeA1ee66lIVqzKlYursAII6z5t0e6rXgwUMJSV4dshBTNacNpZHbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.6.tgz",
+      "integrity": "sha512-izX+5CnkpON3NQGcEm3/d7LfFQNo9ZpFtX2QsINgCYK9LT2VCIdi8D3bMaMSNhrAJCznRoAkFic76uvLroALBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.98.2",
+    "@tanstack/react-query": "^5.80.6",
     "bip39": "^3.0.4",
     "qrcode": "^1.5.1",
     "react": "^19.1.0",
@@ -33,10 +34,10 @@
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "jsdom": "^24.0.0",
+    "prettier": "^3.2.5",
     "ts-jest": "^29.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5",
-    "prettier": "^3.2.5"
+    "vite": "^6.3.5"
   }
 }

--- a/client/src/hooks/useCopyTrading.ts
+++ b/client/src/hooks/useCopyTrading.ts
@@ -1,0 +1,55 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchFollowers,
+  followTrader,
+  unfollowTrader,
+  FollowedTrader,
+  Trader,
+} from '../services/copy';
+
+export default function useCopyTrading() {
+  const queryClient = useQueryClient();
+
+  const {
+    data: followers = [],
+    isLoading,
+    error,
+  } = useQuery<FollowedTrader[]>({
+    queryKey: ['followers'],
+    queryFn: fetchFollowers,
+  });
+
+  const followMutation = useMutation({
+    mutationFn: followTrader,
+    onSuccess: (data) => {
+      queryClient.setQueryData(['followers'], data);
+    },
+  });
+
+  const unfollowMutation = useMutation({
+    mutationFn: unfollowTrader,
+    onSuccess: (data) => {
+      queryClient.setQueryData(['followers'], data);
+    },
+  });
+
+  const updateFollower = (
+    address: string,
+    updater: (t: FollowedTrader) => FollowedTrader,
+  ) => {
+    queryClient.setQueryData<FollowedTrader[]>(['followers'], (old = []) =>
+      old.map((t) => (t.address === address ? updater(t) : t)),
+    );
+  };
+
+  return {
+    followers,
+    isLoading,
+    error,
+    follow: followMutation.mutate,
+    followStatus: followMutation.status,
+    unfollow: unfollowMutation.mutate,
+    unfollowStatus: unfollowMutation.status,
+    updateFollower,
+  };
+}

--- a/client/src/pages/CopyTrading.tsx
+++ b/client/src/pages/CopyTrading.tsx
@@ -1,14 +1,6 @@
-import { useEffect, useState } from 'react';
-
-interface Trader {
-  alias: string;
-  address: string;
-}
-
-interface FollowedTrader extends Trader {
-  copyPercent: number;
-  active: boolean;
-}
+import { useState } from 'react';
+import type { Trader, FollowedTrader } from '../services/copy';
+import useCopyTrading from '../hooks/useCopyTrading';
 
 const popularTraders: Trader[] = [
   { alias: 'Trader Alpha', address: '0xAlpha' },
@@ -18,39 +10,27 @@ const popularTraders: Trader[] = [
 
 export default function CopyTrading() {
   const [search, setSearch] = useState('');
-  const [followed, setFollowed] = useState<FollowedTrader[]>([]);
-
-  useEffect(() => {
-    const stored = localStorage.getItem('followedTraders');
-    if (stored) {
-      setFollowed(JSON.parse(stored));
-    }
-  }, []);
-
-  useEffect(() => {
-    localStorage.setItem('followedTraders', JSON.stringify(followed));
-  }, [followed]);
+  const {
+    followers: followed,
+    follow,
+    unfollow,
+    updateFollower,
+  } = useCopyTrading();
 
   const handleFollow = (trader: Trader) => {
-    setFollowed(prev => {
-      if (prev.find(t => t.address === trader.address)) {
-        return prev.filter(t => t.address !== trader.address);
-      } else {
-        return [...prev, { ...trader, copyPercent: 100, active: true }];
-      }
-    });
+    if (followed.some((t) => t.address === trader.address)) {
+      unfollow(trader.address);
+    } else {
+      follow(trader);
+    }
   };
 
   const updatePercent = (address: string, percent: number) => {
-    setFollowed(prev =>
-      prev.map(t => (t.address === address ? { ...t, copyPercent: percent } : t))
-    );
+    updateFollower(address, (t) => ({ ...t, copyPercent: percent }));
   };
 
   const toggleActive = (address: string) => {
-    setFollowed(prev =>
-      prev.map(t => (t.address === address ? { ...t, active: !t.active } : t))
-    );
+    updateFollower(address, (t) => ({ ...t, active: !t.active }));
   };
 
   const filtered = popularTraders.filter(t =>

--- a/client/src/services/copy.ts
+++ b/client/src/services/copy.ts
@@ -1,0 +1,46 @@
+export interface Trader {
+  alias: string;
+  address: string;
+}
+
+export interface FollowedTrader extends Trader {
+  copyPercent: number;
+  active: boolean;
+}
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+export async function fetchFollowers(): Promise<FollowedTrader[]> {
+  const res = await fetch(`${API_URL}/api/copy/followers`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch followers');
+  }
+  const json = await res.json();
+  return json.followers ?? json;
+}
+
+export async function followTrader(trader: Trader): Promise<FollowedTrader[]> {
+  const res = await fetch(`${API_URL}/api/copy/follow`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(trader),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to follow trader');
+  }
+  const json = await res.json();
+  return json.followers ?? json;
+}
+
+export async function unfollowTrader(address: string): Promise<FollowedTrader[]> {
+  const res = await fetch(`${API_URL}/api/copy/unfollow`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ address }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to unfollow trader');
+  }
+  const json = await res.json();
+  return json.followers ?? json;
+}

--- a/server/tests/security.test.js
+++ b/server/tests/security.test.js
@@ -16,6 +16,7 @@ describe('/api/security', () => {
     expect(res.body).toHaveProperty('score');
     expect(Array.isArray(res.body.topHolders)).toBe(true);
     expect(res.body).toHaveProperty('properties');
+  });
 
   it('returns mock security info for a token', async () => {
     const res = await request(app).get('/api/security?token=TEST');
@@ -25,6 +26,5 @@ describe('/api/security', () => {
     expect(Array.isArray(res.body.topHolders)).toBe(true);
     expect(res.body).toHaveProperty('properties');
     expect(res.body).toHaveProperty('critical', false);
-
   });
 });


### PR DESCRIPTION
## Summary
- add `@tanstack/react-query` dependency
- implement `fetchFollowers`, `followTrader` and `unfollowTrader` service APIs
- create `useCopyTrading` hook based on React Query
- wire CopyTrading page to the new hook
- fix malformed `security.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684773082efc832e8ff4280432613b30