### PR TITLE
Implement PrivateRoute using WalletContext

### DIFF
--- a/client/src/WalletContext.tsx
+++ b/client/src/WalletContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+type WalletContextType = {
+  publicKey: string | null;
+  setPublicKey: (key: string | null) => void;
+};
+
+const WalletContext = createContext<WalletContextType>({
+  publicKey: null,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setPublicKey: () => {},
+});
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+
+  return (
+    <WalletContext.Provider value={{ publicKey, setPublicKey }}>
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export const useWallet = () => useContext(WalletContext);
+
+export default WalletContext;

--- a/client/src/components/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute.tsx
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import WalletContext from '../WalletContext';
+
+export default function PrivateRoute() {
+  const { publicKey } = useContext(WalletContext);
+  return publicKey ? <Outlet /> : <Navigate to="/login" replace />;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { WalletProvider } from './WalletContext'
 
 const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null
 if (savedTheme === 'dark' || savedTheme === 'light') {
@@ -10,6 +11,8 @@ if (savedTheme === 'dark' || savedTheme === 'light') {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <WalletProvider>
+      <App />
+    </WalletProvider>
   </StrictMode>,
 )

--- a/server/tests/security.test.js
+++ b/server/tests/security.test.js
@@ -16,6 +16,7 @@ describe('/api/security', () => {
     expect(res.body).toHaveProperty('score');
     expect(Array.isArray(res.body.topHolders)).toBe(true);
     expect(res.body).toHaveProperty('properties');
+  });
 
   it('returns mock security info for a token', async () => {
     const res = await request(app).get('/api/security?token=TEST');
@@ -25,6 +26,5 @@ describe('/api/security', () => {
     expect(Array.isArray(res.body.topHolders)).toBe(true);
     expect(res.body).toHaveProperty('properties');
     expect(res.body).toHaveProperty('critical', false);
-
   });
 });


### PR DESCRIPTION
## Summary
- add simple `WalletContext` for storing a `publicKey`
- provide `WalletProvider` at app root
- create `PrivateRoute` component to enforce login when no `publicKey`
- fix malformed `security.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847730dd498832eb1871f308f5fcd0d