### PR TITLE
Add ErrorBoundary wrapper

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Error caught by ErrorBoundary:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" className="p-4 text-center">
+          <h1>Oops! Something went wrong.</h1>
+          <p>Please refresh the page or try again later.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css';
 import App from './App.tsx';
 import { WalletProvider } from './context/WalletContext';
 import { ThemeProvider } from './context/ThemeContext';
+import ErrorBoundary from './components/ErrorBoundary';
 
 // Inicializa React Query Client
 const queryClient = new QueryClient();
@@ -14,12 +15,14 @@ const queryClient = new QueryClient();
 // Montaje de la aplicación en el root con un único App
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <WalletProvider>
-        <ThemeProvider>
-          <App />
-        </ThemeProvider>
-      </WalletProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <WalletProvider>
+          <ThemeProvider>
+            <App />
+          </ThemeProvider>
+        </WalletProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- implement client-side ErrorBoundary component
- wrap main providers with ErrorBoundary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d27764760832ea118a1aa1655f3c3