### PR TITLE
Check VITE_RPC_URL before creating connections

### DIFF
--- a/client/src/hooks/useWallet.ts
+++ b/client/src/hooks/useWallet.ts
@@ -36,6 +36,13 @@ export default function useWallet(): WalletState {
 
   useEffect(() => {
     if (publicKey) {
+      if (
+        typeof rpcUrl !== 'string' ||
+        rpcUrl.trim() === '' ||
+        !rpcUrl.startsWith('http')
+      ) {
+        throw new Error('VITE_RPC_URL not configured');
+      }
       const connection = new Connection(rpcUrl);
       connection
         .getBalance(new PublicKey(publicKey))

--- a/client/src/pages/Send.tsx
+++ b/client/src/pages/Send.tsx
@@ -13,6 +13,13 @@ export default function Send() {
     const key = localStorage.getItem('wallet')
     if (key) {
       const rpcUrl = import.meta.env.VITE_RPC_URL
+      if (
+        typeof rpcUrl !== 'string' ||
+        rpcUrl.trim() === '' ||
+        !rpcUrl.startsWith('http')
+      ) {
+        throw new Error('VITE_RPC_URL not configured')
+      }
       const connection = new Connection(rpcUrl)
       connection.getBalance(new PublicKey(key)).then((lamports: number) => {
         setBalance(lamports / 1e9)


### PR DESCRIPTION
## Summary
- validate `VITE_RPC_URL` in wallet hooks and Send page
- throw an error if the RPC URL is missing or invalid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d27749578832ebac513b7f86b4361