### PR TITLE
Fix Alert import in Alerts page

### DIFF
--- a/client/src/pages/Alerts.tsx
+++ b/client/src/pages/Alerts.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import NewAlertModal from '../components/NewAlertModal';
-import { useAlerts, Alert } from '../hooks/useAlerts';
+import { useAlerts } from '../hooks/useAlerts';
+import type { Alert } from '../hooks/useAlerts';
 
 export default function Alerts() {
   const { alerts, updateAlert } = useAlerts();


### PR DESCRIPTION
## Summary
- fix alert hook import in Alerts page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2fc37474832ea67b16b8a718be40